### PR TITLE
fix(highlight): check if src_line exists before trying to highlight it

### DIFF
--- a/lua/quicker/display.lua
+++ b/lua/quicker/display.lua
@@ -180,6 +180,9 @@ local function add_item_highlights_from_buf(qfbufnr, item, line, lnum)
   local ns = vim.api.nvim_create_namespace("quicker_highlights")
   -- TODO re-apply highlights when a buffer is loaded or a LSP receives semantic tokens
   local src_line = vim.api.nvim_buf_get_lines(item.bufnr, item.lnum - 1, item.lnum, false)[1]
+  if not src_line then
+    return
+  end
 
   -- If the lines differ only in leading whitespace, we should add highlights anyway and adjust
   -- the offset.


### PR DESCRIPTION
If a quickfix entry has no text, the highlighting will fail. Instead, I added a nil check to avoid to run the highlighting function early if there is no text to highlight

I encountered this after sending the result of `:FzfLua files` to the quickfixlist