### PR TITLE
fix: render qf entries with an associated buf and no text correctly

### DIFF
--- a/lua/quicker/display.lua
+++ b/lua/quicker/display.lua
@@ -49,20 +49,16 @@ local sign_highlight_map = {
 
 ---@param item QuickFixItem
 local function get_filename_from_item(item)
-  if item.valid == 1 then
-    if item.module and item.module ~= "" then
-      return item.module
-    elseif item.bufnr > 0 then
-      local bufname = vim.api.nvim_buf_get_name(item.bufnr)
-      local path = fs.shorten_path(bufname)
-      local max_len = config.max_filename_width()
-      if path:len() > max_len then
-        path = "…" .. path:sub(path:len() - max_len - 1)
-      end
-      return path
-    else
-      return ""
+  if item.valid == 1 and item.module and item.module ~= "" then
+    return item.module
+  elseif item.bufnr > 0 then
+    local bufname = vim.api.nvim_buf_get_name(item.bufnr)
+    local path = fs.shorten_path(bufname)
+    local max_len = config.max_filename_width()
+    if path:len() > max_len then
+      path = "…" .. path:sub(path:len() - max_len - 1)
     end
+    return path
   else
     return ""
   end
@@ -409,12 +405,9 @@ function M.quickfixtextfunc(info)
       table.insert(ret, table.concat(pieces, ""))
     else
       -- Non-matching line, either from context or normal QF results parsed with errorformat
-      local lnum = user_data.lnum or " "
-      local pieces = {
-        string.rep(" ", col_width),
-        lnum_fmt:format(lnum),
-        remove_prefix(item.text, prefixes[item.bufnr]),
-      }
+      local pieces = { rpad(get_filename_from_item(item), col_width) }
+      table.insert(pieces, string.rep(" ", lnum_width))
+      table.insert(pieces, remove_prefix(item.text, prefixes[item.bufnr]))
       table.insert(ret, table.concat(pieces, b.vert))
     end
   end


### PR DESCRIPTION
qflist entries with no `text` but with `bufnr` were incorrectly rendered as

```
  |  |  
```

I changed the code to show the buffer name if they have one, but maybe the previous `else` with an empty representation in the quickfixlist had a use case that I haven't think of and this PR breaks.

Note: this entries do not contain `valid = 1`, that's why I moved the path of `get_filename_from_item` that gets the filename from `bufnr` out of the `valid = 1` check (my guess is that this is because `text` is empty (?), I don't really understand what the help file says `valid` means)

> 			valid	|TRUE|: recognized error message

edit: `value` -> `valid`