### PR TITLE
fix: error when adding qf entries from telescope / `:vim`

### DIFF
--- a/lua/quicker/display.lua
+++ b/lua/quicker/display.lua
@@ -192,7 +192,7 @@ local function add_item_highlights_from_buf(qfbufnr, item, line, lnum)
   -- Only add highlights if the text in the quickfix matches the source line
   if item.text:sub(item_space + 1) == src_line:sub(src_space + 1) then
     local offset = line:find(b.vert, 1, true)
-    offset = line:find(b.vert, offset + b.vert:len(), true) + b.vert:len() - 1
+    offset = line:find(b.vert, (offset or 0) + b.vert:len(), true) + b.vert:len() - 1
     offset = offset - (prefixes[item.bufnr] or ""):len()
     offset = offset - src_space + item_space
 


### PR DESCRIPTION
Truthfully I have no clue why this error happened and what it implies, but defaulting to zero worked and doesn't seem to give me any issues anymore.
I tried removing my change just now to re-get the error, and yet the bug didn't happen again.
