### PR TITLE
fix(editor): load buffer if necessary before save_changes

### DIFF
--- a/lua/quicker/editor.lua
+++ b/lua/quicker/editor.lua
@@ -274,6 +274,9 @@ local function save_changes(bufnr, loclist_win)
 
       local item = qf_list.items[found_idx]
       if item.bufnr ~= 0 and item.lnum ~= 0 then
+        if not vim.api.nvim_buf_is_loaded(item.bufnr) then
+          vim.fn.bufload(item.bufnr)
+        end
         -- add the whitespace prefix back to the parsed line text
         parsed.text = (prefixes[item.bufnr] or "") .. parsed.text
 


### PR DESCRIPTION
`context.lua` checks whether the buffer is loaded before calling `nvim_buf_get_lines`

https://github.com/stevearc/quicker.nvim/blob/7a64d4ea2b641cc8671443d0ff26de2924894c9f/lua/quicker/context.lua#L235-L237

`editor.lua`does not do the same

https://github.com/stevearc/quicker.nvim/blob/7a64d4ea2b641cc8671443d0ff26de2924894c9f/lua/quicker/editor.lua#L276

this can result in errors if

```lua
    highlight = {
      load_buffers = false,
    }
```

is present in the configuration of the plugin (or if the user does not expand the surrounding context before editing a result in the quickfixlist)