### PR TITLE
looks: when there is no file, display a single bar in the quickfix

### DIFF
--- a/lua/quicker/display.lua
+++ b/lua/quicker/display.lua
@@ -429,11 +429,12 @@ function M.quickfixtextfunc(info)
     if item.valid == 1 then
       -- Matching line
       local lnum = item.lnum == 0 and " " or item.lnum
-      local pieces = {
-        rpad(get_filename_from_item(item), col_width),
-        lnum_fmt:format(lnum),
-        remove_prefix(item.text, prefixes[item.bufnr]),
-      }
+      local pieces = {}
+      if col_width > 1 then
+        table.insert(pieces, rpad(get_filename_from_item(item), col_width))
+      end
+      table.insert(pieces, lnum_fmt:format(lnum))
+      table.insert(pieces, remove_prefix(item.text, prefixes[item.bufnr]))
       table.insert(ret, table.concat(pieces, b.vert))
     elseif user_data.header == "hard" then
       -- Header when expanded QF list
@@ -467,20 +468,22 @@ function M.quickfixtextfunc(info)
       table.insert(ret, table.concat(pieces, ""))
     elseif user_data.lnum then
       -- Non-matching line from quicker.nvim context lines
-      local pieces = {
-        string.rep(" ", col_width),
-        lnum_fmt:format(user_data.lnum),
-        remove_prefix(item.text, prefixes[item.bufnr]),
-      }
+      local pieces = {}
+      if col_width > 1 then
+        table.insert(pieces, string.rep(" ", col_width))
+      end
+      table.insert(pieces, lnum_fmt:format(user_data.lnum))
+      table.insert(pieces, remove_prefix(item.text, prefixes[item.bufnr]))
       table.insert(ret, table.concat(pieces, b.vert))
     else
       -- Other non-matching line
       local lnum = item.lnum == 0 and " " or item.lnum
-      local pieces = {
-        rpad(get_filename_from_item(item), col_width),
-        lnum_fmt:format(lnum),
-        remove_prefix(item.text, prefixes[item.bufnr]),
-      }
+      local pieces = {}
+      if col_width > 1 then
+        table.insert(pieces, rpad(get_filename_from_item(item), col_width))
+      end
+      table.insert(pieces, lnum_fmt:format(lnum))
+      table.insert(pieces, remove_prefix(item.text, prefixes[item.bufnr]))
       table.insert(ret, table.concat(pieces, b.vert))
     end
   end


### PR DESCRIPTION
it's really a question of aesthetics. i'm often dealing with quickfix lists not mapped to any files. in that case the display is
```
 |  |data
```
I find it ugly, so this changes it in that case to just:
```
  |data
```
I don't think we can do much better. If we don't put anything then vim puts `||`  anyway, which is even worse. Maybe we could have a single leading space, maybe a space after the bar or something, but this seems quite diminishing returns. And a space after the bar will be visible on many configs which highlight trailing spaces. I think after this change, the display is good enough and to my eyes much better than with the double separator.