### PR TITLE
feat: enhance height handling, add view argument to open()/toggle()

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Toggle the quickfix or loclist window.
 | >focus         | `nil\|boolean`             | Focus the quickfix window after toggling (default false)                                    |
 | >height        | `nil\|integer`             | Height of the quickfix window when opened. Defaults to number of items in the list.         |
 | >min_height    | `nil\|integer`             | Minimum height of the quickfix window. Ignored if height is defined explicitly. Default 4.  |
-| >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Ignored if height is defined explicitly. Default 10. |
+| >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Ignored if height is defined explicitly. Default 16. |
 | >open_cmd_mods | `nil\|quicker.OpenCmdMods` | A table of modifiers for the quickfix or loclist open commands.                             |
 | >view          | `nil\|quicker.WinViewDict` | A table of options to restore the view of the quickfix window. Can be used to set the cursor or scroll positions (see `winsaveview()`). |
 
@@ -347,7 +347,7 @@ Open the quickfix or loclist window.
 | >focus         | `nil\|boolean`             | Focus the quickfix window after toggling (default false)                                    |
 | >height        | `nil\|integer`             | Height of the quickfix window when opened. Defaults to number of items in the list.         |
 | >min_height    | `nil\|integer`             | Minimum height of the quickfix window. Ignored if height is defined explicitly. Default 4.  |
-| >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Ignored if height is defined explicitly. Default 10. |
+| >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Ignored if height is defined explicitly. Default 16. |
 | >open_cmd_mods | `nil\|quicker.OpenCmdMods` | A table of modifiers for the quickfix or loclist open commands.                             |
 | >view          | `nil\|quicker.WinViewDict` | A table of options to restore the view of the quickfix window. Can be used to set the cursor or scroll positions (see `winsaveview()`). |
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,15 @@ require("quicker").setup({
   },
   -- Set to false to disable the default options in `opts`
   use_default_opts = true,
+  -- Restore the previous quickfix window view parameters, such as height and cursor position, on `quicker.open` and `quicker.toggle`
+  winrestore = {
+    -- Restore the height of the quickfix window
+    height = false,
+    -- Respect the min_height and max_height arguments for `quicker.open` and `quicker.toggle`
+    height_minmax = false,
+    -- Restore cursor and scroll positions. See `:h winsaveview()`
+    view = true,
+  },
   -- Keymaps to set for the quickfix buffer
   keys = {
     -- { ">", "<cmd>lua require('quicker').expand()<CR>", desc = "Expand quickfix content" },

--- a/README.md
+++ b/README.md
@@ -324,30 +324,30 @@ Update the quickfix list with the current buffer text for each item.
 `toggle(opts)` \
 Toggle the quickfix or loclist window.
 
-| Param          | Type                       | Desc                                                                                |
-| -------------- | -------------------------- | ----------------------------------------------------------------------------------- |
-| opts           | `nil\|quicker.OpenOpts`    |                                                                                     |
-| >loclist       | `nil\|boolean`             | Toggle the loclist instead of the quickfix list                                     |
-| >focus         | `nil\|boolean`             | Focus the quickfix window after toggling (default false)                            |
-| >height        | `nil\|integer`             | Height of the quickfix window when opened. Defaults to number of items in the list. |
-| >min_height    | `nil\|integer`             | Minimum height of the quickfix window. Default 4.                                   |
-| >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Default 10.                                  |
-| >open_cmd_mods | `nil\|quicker.OpenCmdMods` | A table of modifiers for the quickfix or loclist open commands.                     |
+| Param          | Type                       | Desc                                                                                        |
+| -------------- | -------------------------- | ------------------------------------------------------------------------------------------- |
+| opts           | `nil\|quicker.OpenOpts`    |                                                                                             |
+| >loclist       | `nil\|boolean`             | Toggle the loclist instead of the quickfix list                                             |
+| >focus         | `nil\|boolean`             | Focus the quickfix window after toggling (default false)                                    |
+| >height        | `nil\|integer`             | Height of the quickfix window when opened. Defaults to number of items in the list.         |
+| >min_height    | `nil\|integer`             | Minimum height of the quickfix window. Ignored if height is defined explicitly. Default 4.  |
+| >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Ignored if height is defined explicitly. Default 10. |
+| >open_cmd_mods | `nil\|quicker.OpenCmdMods` | A table of modifiers for the quickfix or loclist open commands.                             |
 
 ### open(opts)
 
 `open(opts)` \
 Open the quickfix or loclist window.
 
-| Param          | Type                       | Desc                                                                                |
-| -------------- | -------------------------- | ----------------------------------------------------------------------------------- |
-| opts           | `nil\|quicker.OpenOpts`    |                                                                                     |
-| >loclist       | `nil\|boolean`             | Toggle the loclist instead of the quickfix list                                     |
-| >focus         | `nil\|boolean`             | Focus the quickfix window after toggling (default false)                            |
-| >height        | `nil\|integer`             | Height of the quickfix window when opened. Defaults to number of items in the list. |
-| >min_height    | `nil\|integer`             | Minimum height of the quickfix window. Default 4.                                   |
-| >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Default 10.                                  |
-| >open_cmd_mods | `nil\|quicker.OpenCmdMods` | A table of modifiers for the quickfix or loclist open commands.                     |
+| Param          | Type                       | Desc                                                                                        |
+| -------------- | -------------------------- | ------------------------------------------------------------------------------------------- |
+| opts           | `nil\|quicker.OpenOpts`    |                                                                                             |
+| >loclist       | `nil\|boolean`             | Toggle the loclist instead of the quickfix list                                             |
+| >focus         | `nil\|boolean`             | Focus the quickfix window after toggling (default false)                                    |
+| >height        | `nil\|integer`             | Height of the quickfix window when opened. Defaults to number of items in the list.         |
+| >min_height    | `nil\|integer`             | Minimum height of the quickfix window. Ignored if height is defined explicitly. Default 4.  |
+| >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Ignored if height is defined explicitly. Default 10. |
+| >open_cmd_mods | `nil\|quicker.OpenCmdMods` | A table of modifiers for the quickfix or loclist open commands.                             |
 
 ### close(opts)
 

--- a/README.md
+++ b/README.md
@@ -182,15 +182,6 @@ require("quicker").setup({
   },
   -- Set to false to disable the default options in `opts`
   use_default_opts = true,
-  -- Restore the previous quickfix window view parameters, such as height and cursor position, on `quicker.open` and `quicker.toggle`
-  winrestore = {
-    -- Restore the height of the quickfix window
-    height = false,
-    -- Respect the min_height and max_height arguments for `quicker.open` and `quicker.toggle`
-    height_minmax = false,
-    -- Restore cursor and scroll positions. See `:h winsaveview()`
-    view = true,
-  },
   -- Keymaps to set for the quickfix buffer
   keys = {
     -- { ">", "<cmd>lua require('quicker').expand()<CR>", desc = "Expand quickfix content" },

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ Toggle the quickfix or loclist window.
 | >min_height    | `nil\|integer`             | Minimum height of the quickfix window. Ignored if height is defined explicitly. Default 4.  |
 | >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Ignored if height is defined explicitly. Default 10. |
 | >open_cmd_mods | `nil\|quicker.OpenCmdMods` | A table of modifiers for the quickfix or loclist open commands.                             |
+| >view          | `nil\|quicker.WinViewDict` | A table of options to restore the view of the quickfix window. Can be used to set the cursor or scroll positions (see `winsaveview()`). |
 
 ### open(opts)
 
@@ -348,6 +349,7 @@ Open the quickfix or loclist window.
 | >min_height    | `nil\|integer`             | Minimum height of the quickfix window. Ignored if height is defined explicitly. Default 4.  |
 | >max_height    | `nil\|integer`             | Maximum height of the quickfix window. Ignored if height is defined explicitly. Default 10. |
 | >open_cmd_mods | `nil\|quicker.OpenCmdMods` | A table of modifiers for the quickfix or loclist open commands.                             |
+| >view          | `nil\|quicker.WinViewDict` | A table of options to restore the view of the quickfix window. Can be used to set the cursor or scroll positions (see `winsaveview()`). |
 
 ### close(opts)
 

--- a/lua/quicker/config.lua
+++ b/lua/quicker/config.lua
@@ -10,6 +10,13 @@ local default_config = {
   },
   -- Set to false to disable the default options in `opts`
   use_default_opts = true,
+  -- Restore the previous quickfix window view parameters, such as height and cursor position, on `quicker.open` and `quicker.toggle`
+  winrestore = {
+    -- Restore the height of the quickfix window
+    height = false,
+    -- Restore cursor and scroll positions. See `:h winsaveview()`
+    view = true,
+  },
   -- Keymaps to set for the quickfix buffer
   keys = {
     -- { ">", "<cmd>lua require('quicker').expand()<CR>", desc = "Expand quickfix content" },
@@ -76,6 +83,7 @@ local default_config = {
 ---@field opts table<string, any>
 ---@field keys quicker.Keymap[]
 ---@field use_default_opts boolean
+---@field winrestore quicker.WinRestoreConfig
 ---@field constrain_cursor boolean
 ---@field highlight quicker.HighlightConfig
 ---@field follow quicker.FollowConfig
@@ -92,6 +100,7 @@ local M = {}
 ---@field opts? table<string, any> Local options to set for quickfix
 ---@field keys? quicker.Keymap[] Keymaps to set for the quickfix buffer
 ---@field use_default_opts? boolean Set to false to disable the default options in `opts`
+---@field winrestore? quicker.SetupWinRestoreConfig -- Restore the previous quickfix window view parameters, such as height and cursor position, on `quicker.open` and `quicker.toggle`
 ---@field constrain_cursor? boolean Keep the cursor to the right of the filename and lnum columns
 ---@field highlight? quicker.SetupHighlightConfig Configure syntax highlighting
 ---@field follow? quicker.SetupFollowConfig Configure cursor following
@@ -152,6 +161,14 @@ end
 ---@field soft_header? string Soft headers separate results within the same file
 ---@field soft_cross? string
 ---@field soft_end? string
+
+---@class (exact) quicker.WinRestoreConfig
+---@field height boolean
+---@field view boolean
+
+---@class (exact) quicker.SetupWinRestoreConfig
+---@field height? boolean
+---@field view? boolean
 
 ---@class (exact) quicker.HighlightConfig
 ---@field treesitter boolean

--- a/lua/quicker/config.lua
+++ b/lua/quicker/config.lua
@@ -14,6 +14,8 @@ local default_config = {
   winrestore = {
     -- Restore the height of the quickfix window
     height = false,
+    -- Respect the min_height and max_height arguments for `quicker.open` and `quicker.toggle`
+    height_minmax = false,
     -- Restore cursor and scroll positions. See `:h winsaveview()`
     view = true,
   },
@@ -164,10 +166,12 @@ end
 
 ---@class (exact) quicker.WinRestoreConfig
 ---@field height boolean
+---@field height_minmax boolean
 ---@field view boolean
 
 ---@class (exact) quicker.SetupWinRestoreConfig
 ---@field height? boolean
+---@field height_minmax? boolean
 ---@field view? boolean
 
 ---@class (exact) quicker.HighlightConfig

--- a/lua/quicker/config.lua
+++ b/lua/quicker/config.lua
@@ -10,15 +10,6 @@ local default_config = {
   },
   -- Set to false to disable the default options in `opts`
   use_default_opts = true,
-  -- Restore the previous quickfix window view parameters, such as height and cursor position, on `quicker.open` and `quicker.toggle`
-  winrestore = {
-    -- Restore the height of the quickfix window
-    height = false,
-    -- Respect the min_height and max_height arguments for `quicker.open` and `quicker.toggle`
-    height_minmax = false,
-    -- Restore cursor and scroll positions. See `:h winsaveview()`
-    view = true,
-  },
   -- Keymaps to set for the quickfix buffer
   keys = {
     -- { ">", "<cmd>lua require('quicker').expand()<CR>", desc = "Expand quickfix content" },
@@ -85,7 +76,6 @@ local default_config = {
 ---@field opts table<string, any>
 ---@field keys quicker.Keymap[]
 ---@field use_default_opts boolean
----@field winrestore quicker.WinRestoreConfig
 ---@field constrain_cursor boolean
 ---@field highlight quicker.HighlightConfig
 ---@field follow quicker.FollowConfig
@@ -102,7 +92,6 @@ local M = {}
 ---@field opts? table<string, any> Local options to set for quickfix
 ---@field keys? quicker.Keymap[] Keymaps to set for the quickfix buffer
 ---@field use_default_opts? boolean Set to false to disable the default options in `opts`
----@field winrestore? quicker.SetupWinRestoreConfig -- Restore the previous quickfix window view parameters, such as height and cursor position, on `quicker.open` and `quicker.toggle`
 ---@field constrain_cursor? boolean Keep the cursor to the right of the filename and lnum columns
 ---@field highlight? quicker.SetupHighlightConfig Configure syntax highlighting
 ---@field follow? quicker.SetupFollowConfig Configure cursor following
@@ -163,16 +152,6 @@ end
 ---@field soft_header? string Soft headers separate results within the same file
 ---@field soft_cross? string
 ---@field soft_end? string
-
----@class (exact) quicker.WinRestoreConfig
----@field height boolean
----@field height_minmax boolean
----@field view boolean
-
----@class (exact) quicker.SetupWinRestoreConfig
----@field height? boolean
----@field height_minmax? boolean
----@field view? boolean
 
 ---@class (exact) quicker.HighlightConfig
 ---@field treesitter boolean

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -109,7 +109,7 @@ M.is_open = function(loclist_win)
 end
 
 ---@class quicker.OpenCmdMods: vim.api.keyset.parse_cmd.mods
----@class quicker.WinViewDict: vim.fn.winrestview.dict
+---@alias quicker.WinViewDict vim.fn.winrestview.dict
 
 ---@class (exact) quicker.OpenOpts
 ---@field loclist? boolean Toggle the loclist instead of the quickfix list

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -121,7 +121,7 @@ end
 ---Toggle the quickfix or loclist window.
 ---@param opts? quicker.OpenOpts
 M.toggle = function(opts)
-  ---@type {loclist: boolean, focus: boolean, height?: integer, min_height: integer, max_height: integer, open_cmd_mods?: quicker.OpenCmdMods}
+  ---@type {loclist: boolean, focus: boolean, height?: integer, min_height: integer, max_height: integer, open_cmd_mods: quicker.OpenCmdMods}
   opts = vim.tbl_deep_extend("keep", opts or {}, {
     loclist = false,
     focus = false,
@@ -141,7 +141,7 @@ end
 ---@param opts? quicker.OpenOpts
 M.open = function(opts)
   local util = require("quicker.util")
-  ---@type {loclist: boolean, focus: boolean, height?: integer, min_height: integer, max_height: integer, open_cmd_mods?: quicker.OpenCmdMods}
+  ---@type {loclist: boolean, focus: boolean, height?: integer, min_height: integer, max_height: integer, open_cmd_mods: quicker.OpenCmdMods}
   opts = vim.tbl_deep_extend("keep", opts or {}, {
     loclist = false,
     focus = false,

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -155,6 +155,10 @@ M.open = function(opts)
     max_height = 10,
     open_cmd_mods = {},
   })
+
+  local from_winid = vim.fn.win_getid()
+  local from_winview = vim.fn.winsaveview()
+
   local winrestore
   local height
   if opts.loclist then
@@ -183,8 +187,13 @@ M.open = function(opts)
     vim.fn.winrestview(winrestore.view)
   end
 
-  if not opts.focus then
-    vim.cmd.wincmd({ args = { "p" } })
+  local to_winid = vim.fn.win_getid()
+
+  vim.fn.win_gotoid(from_winid)
+  vim.fn.winrestview(from_winview)
+
+  if opts.focus then
+    vim.fn.win_gotoid(to_winid)
   end
 end
 

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -175,12 +175,6 @@ M.open = function(opts)
     })
   end
 
-  -- only set the height if the quickfix is not a full-height vsplit
-  if not util.is_full_height_vsplit(0) then
-    height = math.min(opts.max_height, math.max(opts.min_height, height))
-    vim.api.nvim_win_set_height(0, height)
-  end
-
   if not vim.tbl_isempty(opts.view) then
     vim.fn.winrestview(opts.view)
   end

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -109,6 +109,7 @@ M.is_open = function(loclist_win)
 end
 
 ---@class quicker.OpenCmdMods: vim.api.keyset.parse_cmd.mods
+---@class quicker.WinViewDict: vim.fn.winrestview.dict
 
 ---@class (exact) quicker.OpenOpts
 ---@field loclist? boolean Toggle the loclist instead of the quickfix list
@@ -117,17 +118,19 @@ end
 ---@field min_height? integer Minimum height of the quickfix window. Default 4.
 ---@field max_height? integer Maximum height of the quickfix window. Default 16.
 ---@field open_cmd_mods? quicker.OpenCmdMods A table of modifiers for the quickfix or loclist open commands.
+---@field view? quicker.WinViewDict A table of options to restore the view of the quickfix window. Can be used to set the cursor or scroll positions (see `winsaveview()`).
 
 ---Toggle the quickfix or loclist window.
 ---@param opts? quicker.OpenOpts
 M.toggle = function(opts)
-  ---@type {loclist: boolean, focus: boolean, height?: integer, min_height: integer, max_height: integer, open_cmd_mods: quicker.OpenCmdMods}
+  ---@type {loclist: boolean, focus: boolean, height?: integer, min_height: integer, max_height: integer, open_cmd_mods: quicker.OpenCmdMods, view: quicker.WinViewDict}
   opts = vim.tbl_deep_extend("keep", opts or {}, {
     loclist = false,
     focus = false,
     min_height = 4,
     max_height = 16,
     open_cmd_mods = {},
+    view = {},
   })
   local loclist_win = opts.loclist and 0 or nil
   if M.is_open(loclist_win) then
@@ -141,13 +144,14 @@ end
 ---@param opts? quicker.OpenOpts
 M.open = function(opts)
   local util = require("quicker.util")
-  ---@type {loclist: boolean, focus: boolean, height?: integer, min_height: integer, max_height: integer, open_cmd_mods: quicker.OpenCmdMods}
+  ---@type {loclist: boolean, focus: boolean, height?: integer, min_height: integer, max_height: integer, open_cmd_mods: quicker.OpenCmdMods, view: quicker.WinViewDict}
   opts = vim.tbl_deep_extend("keep", opts or {}, {
     loclist = false,
     focus = false,
     min_height = 4,
     max_height = 16,
     open_cmd_mods = {},
+    view = {},
   })
   local clamp = function(val)
     return util.clamp(opts.min_height, val, opts.max_height)
@@ -169,6 +173,10 @@ M.open = function(opts)
       count = height,
       mods = opts.open_cmd_mods,
     })
+  end
+
+  if next(opts.view) then
+    vim.fn.winrestview(opts.view)
   end
 
   if not opts.focus then

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -175,10 +175,18 @@ M.open = function(opts)
     height = #vim.fn.getqflist()
   end
 
-  height = math.min(opts.max_height, math.max(opts.min_height, height))
+  local clamp = function(h)
+    return math.min(opts.max_height, math.max(opts.min_height, h))
+  end
+
+  height = clamp(height)
 
   if require("quicker.config").winrestore.height and winrestore.height then
-    height = winrestore.height
+    if require("quicker.config").winrestore.height_minmax then
+      height = clamp(winrestore.height)
+    else
+      height = winrestore.height
+    end
   end
 
   vim.api.nvim_win_set_height(0, height)

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -115,7 +115,7 @@ end
 ---@field focus? boolean Focus the quickfix window after toggling (default false)
 ---@field height? integer Height of the quickfix window when opened. Defaults to number of items in the list.
 ---@field min_height? integer Minimum height of the quickfix window. Default 4.
----@field max_height? integer Maximum height of the quickfix window. Default 10.
+---@field max_height? integer Maximum height of the quickfix window. Default 16.
 ---@field open_cmd_mods? quicker.OpenCmdMods A table of modifiers for the quickfix or loclist open commands.
 
 ---Toggle the quickfix or loclist window.
@@ -126,7 +126,7 @@ M.toggle = function(opts)
     loclist = false,
     focus = false,
     min_height = 4,
-    max_height = 10,
+    max_height = 16,
     open_cmd_mods = {},
   })
   local loclist_win = opts.loclist and 0 or nil
@@ -146,7 +146,7 @@ M.open = function(opts)
     loclist = false,
     focus = false,
     min_height = 4,
-    max_height = 10,
+    max_height = 16,
     open_cmd_mods = {},
   })
   local clamp = function(val)

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -175,7 +175,7 @@ M.open = function(opts)
     })
   end
 
-  if next(opts.view) then
+  if not vim.tbl_isempty(opts.view) then
     vim.fn.winrestview(opts.view)
   end
 

--- a/lua/quicker/util.lua
+++ b/lua/quicker/util.lua
@@ -71,27 +71,6 @@ M.get_lnum_extmarks = function(bufnr, lnum, line_len, ns)
   end, extmarks)
 end
 
----Return true if the window is a full-height leaf window
----@param winid? integer
----@return boolean
-M.is_full_height_vsplit = function(winid)
-  if not winid or winid == 0 then
-    winid = vim.api.nvim_get_current_win()
-  end
-  local layout = vim.fn.winlayout()
-  -- If the top layout is not vsplit, then it's not a vertical leaf
-  if layout[1] ~= "row" then
-    return false
-  end
-  for _, v in ipairs(layout[2]) do
-    if v[1] == "leaf" and v[2] == winid then
-      return true
-    end
-  end
-
-  return false
-end
-
 ---Limit the value to a range between a minimum and maximum
 ---@param min integer
 ---@param val integer

--- a/lua/quicker/util.lua
+++ b/lua/quicker/util.lua
@@ -71,4 +71,12 @@ M.get_lnum_extmarks = function(bufnr, lnum, line_len, ns)
   end, extmarks)
 end
 
+---Limit the value to a range between a minimum and maximum
+---@param min integer
+---@param val integer
+---@param max integer
+M.clamp = function(min, val, max)
+  return math.max(min, math.min(val, max))
+end
+
 return M


### PR DESCRIPTION
1. ~~Add new options~~

```lua
-- Restore the previous quickfix window view parameters, such as height and cursor position, on `quicker.open` and `quicker.toggle`
winrestore = {
  -- Restore the height of the quickfix window
  height = false,
  -- Respect the min_height and max_height arguments for `quicker.open` and `quicker.toggle`
  height_minmax = false,
  -- Restore cursor and scroll positions. See `:h winsaveview()`
  view = true,
},
```

2. Prevent the scroll position from jumping when the quickfix opens

https://github.com/user-attachments/assets/7ce9350d-33ba-4cb7-949f-6d267f34cd97