### PR TITLE
feat: prevent re-adding nested events for the same buffer

### DIFF
--- a/lua/quicker/cursor.lua
+++ b/lua/quicker/cursor.lua
@@ -14,14 +14,14 @@ local function constrain_cursor()
   end
 end
 
----@param bufnr number
-function M.constrain_cursor(bufnr)
+---@param bufnr integer
+---@param aug integer
+function M.constrain_cursor(bufnr, aug)
   -- HACK: we have to defer this call because sometimes the autocmds don't take effect.
   vim.schedule(function()
     if not vim.api.nvim_buf_is_valid(bufnr) then
       return
     end
-    local aug = vim.api.nvim_create_augroup("quicker", { clear = false })
     vim.api.nvim_create_autocmd("InsertEnter", {
       desc = "Constrain quickfix cursor position",
       group = aug,

--- a/lua/quicker/editor.lua
+++ b/lua/quicker/editor.lua
@@ -373,8 +373,8 @@ end
 -- TODO add support for undo past last change
 
 ---@param bufnr integer
-function M.setup_editor(bufnr)
-  local aug = vim.api.nvim_create_augroup("quicker", { clear = false })
+---@param aug integer
+function M.setup_editor(bufnr, aug)
   local loclist_win
   vim.api.nvim_buf_call(bufnr, function()
     local ok, qf = pcall(vim.fn.getloclist, 0, { filewinid = 0 })

--- a/lua/quicker/init.lua
+++ b/lua/quicker/init.lua
@@ -6,13 +6,19 @@ local function setup(opts)
   config.setup(opts)
 
   local aug = vim.api.nvim_create_augroup("quicker", { clear = true })
+  local aug_opts = vim.api.nvim_create_augroup("quicker_opts", { clear = false })
+  local aug_cursor = vim.api.nvim_create_augroup("quicker_cursor", { clear = false })
+  local aug_editor = vim.api.nvim_create_augroup("quicker_editor", { clear = false })
   vim.api.nvim_create_autocmd("FileType", {
     pattern = "qf",
     group = aug,
     desc = "quicker.nvim set up quickfix mappings",
     callback = function(args)
+      vim.api.nvim_clear_autocmds({ group = aug_opts, buffer = args.buf })
+      vim.api.nvim_clear_autocmds({ group = aug_cursor, buffer = args.buf })
+
       require("quicker.highlight").set_highlight_groups()
-      require("quicker.opts").set_opts(args.buf)
+      require("quicker.opts").set_opts(args.buf, aug_opts)
       require("quicker.keys").set_keymaps(args.buf)
       vim.api.nvim_buf_create_user_command(args.buf, "Refresh", function()
         require("quicker.context").refresh()
@@ -21,7 +27,7 @@ local function setup(opts)
       })
 
       if config.constrain_cursor then
-        require("quicker.cursor").constrain_cursor(args.buf)
+        require("quicker.cursor").constrain_cursor(args.buf, aug_cursor)
       end
 
       config.on_qf(args.buf)
@@ -41,7 +47,8 @@ local function setup(opts)
       group = aug,
       desc = "quicker.nvim set up quickfix editing",
       callback = function(args)
-        require("quicker.editor").setup_editor(args.buf)
+        vim.api.nvim_clear_autocmds({ group = aug_editor, buffer = args.buf })
+        require("quicker.editor").setup_editor(args.buf, aug_editor)
       end,
     })
   end

--- a/lua/quicker/opts.lua
+++ b/lua/quicker/opts.lua
@@ -36,13 +36,13 @@ local function set_win_opts(winid)
 end
 
 ---@param bufnr integer
-function M.set_opts(bufnr)
+---@param aug integer
+function M.set_opts(bufnr, aug)
   set_buf_opts(bufnr)
   local winid = util.buf_find_win(bufnr)
   if winid then
     set_win_opts(winid)
   else
-    local aug = vim.api.nvim_create_augroup("quicker", { clear = false })
     vim.api.nvim_create_autocmd("BufWinEnter", {
       desc = "Set quickfix window options",
       buffer = bufnr,


### PR DESCRIPTION
When the quickfix window is toggled, it doesn’t wipe out the buffer. As a result, each time it’s opened (triggering events like `FileType` and `BufReadPost`), the following functions generate new events for the same buffer, causing a leak of events:

- `require("quicker.editor").setup_editor(args.buf)`
- `require("quicker.opts").set_opts(args.buf)`
- `require("quicker.cursor").constrain_cursor(args.buf)`