### PR TITLE
feat: highlight diagnostic message

### DIFF
--- a/lua/quicker/display.lua
+++ b/lua/quicker/display.lua
@@ -381,6 +381,18 @@ add_qf_highlights = function(info)
         }
       end
       vim.api.nvim_buf_set_extmark(qfbufnr, ns, i - 1, 0, mark)
+      vim.api.nvim_buf_set_extmark(
+        qfbufnr,
+        ns,
+        i - 1,
+        line:find(EM_QUAD, 1, true) + EM_QUAD_LEN - 1,
+        {
+          hl_group = virt_text_highlight_map[item.type:upper()],
+          end_col = line:len(),
+          priority = 100,
+          invalidate = true,
+        }
+      )
     end
 
     -- If we've been processing for too long, defer to preserve editor responsiveness


### PR DESCRIPTION
It would be nice to have diagnostic messages highlighted so we can process information faster.

## Before:

<img width="352" height="119" alt="Screenshot 2026-04-05 at 02 31 08" src="https://github.com/user-attachments/assets/a59357d1-15a9-4d5c-914e-ab253f7a744e" />

## After:

<img width="352" height="115" alt="image" src="https://github.com/user-attachments/assets/d3cfe77a-2bbd-4b6a-b49c-be07e5261be2" />
