### PR TITLE
feat: add relative_path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ require("quicker").setup({
   header_length = function(type, start_col)
     return vim.o.columns - start_col
   end,
+  -- Relative path for filenames in list. Can be 'git', 'cwd', a string or a function returning a string
+  relative_path = cwd
 })
 ```
 

--- a/lua/quicker/config.lua
+++ b/lua/quicker/config.lua
@@ -67,6 +67,8 @@ local default_config = {
   header_length = function(type, start_col)
     return vim.o.columns - start_col
   end,
+
+  relative_path = "cwd",
 }
 
 ---@alias quicker.TrimEnum "all"|"common"|false
@@ -85,6 +87,7 @@ local default_config = {
 ---@field trim_leading_whitespace quicker.TrimEnum
 ---@field max_filename_width fun(): integer
 ---@field header_length fun(type: "hard"|"soft", start_col: integer): integer
+---@field relative_path string | 'git' | 'cwd' | fun(): string
 local M = {}
 
 ---@class (exact) quicker.SetupOptions
@@ -101,6 +104,7 @@ local M = {}
 ---@field trim_leading_whitespace? quicker.TrimEnum How to trim the leading whitespace from results
 ---@field max_filename_width? fun(): integer Maximum width of the filename column
 ---@field header_length? fun(type: "hard"|"soft", start_col: integer): integer How far the header should extend to the right
+---@field relative_path? string | 'git' | 'cwd' | fun(): string Relative path for filenames in list
 
 local has_setup = false
 ---@param opts? quicker.SetupOptions

--- a/lua/quicker/display.lua
+++ b/lua/quicker/display.lua
@@ -57,7 +57,8 @@ M.get_filename_from_item = function(item)
     return item.module
   elseif item.bufnr > 0 then
     local bufname = vim.api.nvim_buf_get_name(item.bufnr)
-    local path = fs.shorten_path(bufname)
+    local relative_to = fs.get_relative(config.relative_path)
+    local path = fs.shorten_path(bufname, relative_to)
     local max_len = config.max_filename_width()
     if max_len == 0 then
       return ""

--- a/lua/quicker/fs.lua
+++ b/lua/quicker/fs.lua
@@ -35,13 +35,34 @@ end
 
 local home_dir = assert(vim.uv.os_homedir())
 
+local function get_git_root()
+  local path = vim.fn.getcwd()
+  while path ~= home_dir do
+    if vim.uv.fs_stat(path .. "/.git") then
+      return path
+    end
+    path = vim.fn.fnamemodify(path, ":h")
+  end
+  return nil
+end
+
+---@param path function|string
+M.get_relative = function(path)
+  if not path or path == "cwd" then
+    return vim.fn.getcwd()
+  elseif type(path) == "function" then
+    return path()
+  elseif path == "git" then
+    return get_git_root()
+  else
+    return M.abspath(path)
+  end
+end
+
 ---@param path string
 ---@param relative_to? string Shorten relative to this path (default cwd)
 ---@return string
 M.shorten_path = function(path, relative_to)
-  if not relative_to then
-    relative_to = vim.fn.getcwd()
-  end
   local relpath
   if M.is_subpath(relative_to, path) then
     local idx = relative_to:len() + 1


### PR DESCRIPTION
Add relative_path option for filenames in list, can be a function or a string. When set to 'git' the filename paths are relative to the git root directory. Default is 'cwd'
